### PR TITLE
disable logout on disconnect

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -342,10 +342,12 @@ class Client extends EventEmitter {
         this.pupPage.on('framenavigated', async (frame) => {
             if(frame.url().includes('post_logout=1') || this.lastLoggedOut) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
+
                 // Disable logging out as this was throwing an error for LocalAuth
                 // await this.authStrategy.logout();
                 // await this.authStrategy.beforeBrowserInitialized();
                 // await this.authStrategy.afterBrowserInitialized();
+
                 this.lastLoggedOut = false;
             }
             await this.inject(true);

--- a/src/Client.js
+++ b/src/Client.js
@@ -342,9 +342,9 @@ class Client extends EventEmitter {
         this.pupPage.on('framenavigated', async (frame) => {
             if(frame.url().includes('post_logout=1') || this.lastLoggedOut) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
-                await this.authStrategy.logout();
-                await this.authStrategy.beforeBrowserInitialized();
-                await this.authStrategy.afterBrowserInitialized();
+                // await this.authStrategy.logout();
+                // await this.authStrategy.beforeBrowserInitialized();
+                // await this.authStrategy.afterBrowserInitialized();
                 this.lastLoggedOut = false;
             }
             await this.inject(true);

--- a/src/Client.js
+++ b/src/Client.js
@@ -342,6 +342,7 @@ class Client extends EventEmitter {
         this.pupPage.on('framenavigated', async (frame) => {
             if(frame.url().includes('post_logout=1') || this.lastLoggedOut) {
                 this.emit(Events.DISCONNECTED, 'LOGOUT');
+                // Disable logging out as this was throwing an error for LocalAuth
                 // await this.authStrategy.logout();
                 // await this.authStrategy.beforeBrowserInitialized();
                 // await this.authStrategy.afterBrowserInitialized();


### PR DESCRIPTION
This disables calling `authstrategy.logout()` and related functions when disconnected. When using LocalAuth, the `logout` function was intermittently throwing an error when trying to delete the auth directory which I believe was due to a race condition with another process writing to the directory. This error was can not be handled by the process calling the library as it was running in an eventEmitter. Long term fix in my opinion, would be to identify the race condition and emit an error event instead of throwing an error. 



